### PR TITLE
Bump tested-up-to values to WordPress 6.7 and WooCommerce 9.3.3

### DIFF
--- a/includes/class-wc-customizer-settings.php
+++ b/includes/class-wc-customizer-settings.php
@@ -32,6 +32,10 @@ defined( 'ABSPATH' ) or exit;
  */
 class WC_Customizer_Settings extends WC_Settings_Page {
 
+	/**
+	 * @var array|false|mixed|null
+	 */
+	protected array $customizations = [];
 
 	/**
 	 * Add various admin hooks/filters

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 5.6
 Requires PHP: 7.4
-Tested up to: 6.6.2
+Tested up to: 6.7
 Stable tag: 2.9.0-dev.1
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link: https://www.paypal.com/cgi-bin/webscr?cmd=_xclick&business=paypal@s
 Tags: woocommerce, woocommerce shop, woocommerce filters, woocommerce text
 Requires at least: 5.6
 Requires PHP: 7.4
-Tested up to: 6.2.2
+Tested up to: 6.6.2
 Stable tag: 2.8.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html

--- a/woocommerce-customizer.php
+++ b/woocommerce-customizer.php
@@ -19,7 +19,7 @@
  * @license   http://www.gnu.org/licenses/gpl-3.0.html GNU General Public License v3.0
  *
  * WC requires at least: 3.9.4
- * WC tested up to: 7.9.0
+ * WC tested up to: 9.3.3
  */
 
 defined( 'ABSPATH' ) or exit;


### PR DESCRIPTION
Tested on:
- WordPress 6.7-RC1
- WooCommerce 9.3.3

Also pre-defines `WC_Customizer_Settings::$customizations` to avoid a dynamic property notice from PHP 8.2